### PR TITLE
see the commit message for the remarks

### DIFF
--- a/pompy/models.py
+++ b/pompy/models.py
@@ -912,7 +912,9 @@ class moth_modular(object):
         flips the boolian that determines direction
         """
         self.going_right = not self.going_right
+
     def update_duration(self):
+        """ Docstring are missing """
         if self.T%0.1:
             self.duration = self.base_duration*min(1,self.base_conc/self.conc_max)
         


### PR DESCRIPTION
docstrings
remove obsolete code
run a comparison of a moth from the same initial condition for two models, plot their trajectories (no need for a live video)